### PR TITLE
[zsh] Provides /bin/zsh since requires looks for /bin/zsh shebang.

### DIFF
--- a/rpm/zsh.spec
+++ b/rpm/zsh.spec
@@ -11,6 +11,7 @@ BuildRequires:  pkgconfig(libpcre)
 BuildRequires:  libcap-devel
 BuildRequires:  texinfo
 BuildRequires:  autoconf
+Provides: /bin/zsh
 
 %description
 Zsh is a shell designed for interactive use, although


### PR DESCRIPTION
See https://forum.sailfishos.org/t/installing-zsh-fails/ for bug report. If you looks at Fedora spec, it has this `Provides: /bin/zsh` line : https://src.fedoraproject.org/rpms/zsh/blob/master/f/zsh.spec#_38